### PR TITLE
fix(rebase): remove the fork remote after each rebase run

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,5 +22,10 @@ do
     rebase_failure "$PR_NUMBER" "$REASON"
   fi
 
+  # Remove fork remote for subsequent rebases
+  if [[ "$(git remote)" == *fork* ]]; then
+    git remote remove fork
+  fi
+
   echo "$OUTPUT"
 done


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Brief description. What is this change?

The first time the rebase script is run, it adds a remote called `fork`. This causes subsequent rebase attempts to fail due to `fork` already existing and the subsequent attempts to add `fork` as a remote failing.

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

We now remove `fork` after every run so that the script behaves as intended.

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->


### Checklist

- [X] title of PR reflects the branch name

