### PR TITLE
ci: add labelling to rebase action (VF-2041)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,16 +16,20 @@ function rebase_failure {
   NO_LABEL=$?
 
   # Comment on PR with reason for failure
-  "${COMMENT_ON_FAILURE}" && (( $NO_LABEL )) && /ghcli/bin/gh pr comment $1 --body \
+  if "${COMMENT_ON_FAILURE}" && (( $NO_LABEL )); then
+    /ghcli/bin/gh pr comment $1 --body \
     "Failed to automatically rebase this pull request:$NEWLINE
     $2$NEWLINE
 More details can be found in  workflow \"$GITHUB_WORKFLOW\" at https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+  fi
 
   # Ensure label exists before adding it
-  "${LABEL_ON_FAILURE}" && /ghcli/bin/gh api /repos/{owner}/{repo}/labels --field name="$FAILED_LABEL" --field color="$FAILED_LABEL_COLOR" --field description="$FAILED_LABEL_DESCRIPTION" || true
+  if "${LABEL_ON_FAILURE}"; then
+    /ghcli/bin/gh api /repos/{owner}/{repo}/labels --field name="$FAILED_LABEL" --field color="$FAILED_LABEL_COLOR" --field description="$FAILED_LABEL_DESCRIPTION" || true
 
-  # Add label denoting inability to automatically rebase
-  "${LABEL_ON_FAILURE}" && /ghcli/bin/gh pr edit $1 --add-label "$FAILED_LABEL"
+    # Add label denoting inability to automatically rebase
+    /ghcli/bin/gh pr edit $1 --add-label "$FAILED_LABEL"
+  fi
 }
 
 for PR_NUMBER in $PR_NUMBERS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,8 +23,8 @@ function rebase_failure {
 More details can be found in  workflow \"$GITHUB_WORKFLOW\" at https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
   fi
 
-  # Ensure label exists before adding it
   if "${LABEL_ON_FAILURE}"; then
+    # Ensure label exists before adding it
     /ghcli/bin/gh api /repos/{owner}/{repo}/labels --field name="$FAILED_LABEL" --field color="$FAILED_LABEL_COLOR" --field description="$FAILED_LABEL_DESCRIPTION" || true
 
     # Add label denoting inability to automatically rebase

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,17 +1,25 @@
 #!/bin/bash
 
 NEWLINE=$'\n'
+FAILED_LABEL="unable-auto-rebase"
 
 # Configuration
 : "${COMMENT_ON_FAILURE:=false}" # Whether to comment on the pull request that fails to rebase
+: "${LABEL_ON_FAILURE:=false}" # Whether to label the pull request that fails to rebase
 : "${LOG_LINES:=1}" # Number of log lines to include in pull request comment
 
 function rebase_failure {
+  /ghcli/bin/gh pr view 76 --json labels --jq '.labels[].name' | grep "$FAILED_LABEL" >/dev/null
+  NO_LABEL=$?
+
   # Comment on PR with reason for failure
-  "${COMMENT_ON_FAILURE}" && /ghcli/bin/gh pr comment $PR_NUMBER --body \
+  "${COMMENT_ON_FAILURE}" && (( $NO_LABEL )) && /ghcli/bin/gh pr comment $1 --body \
     "Failed to automatically rebase this pull request:$NEWLINE
     $2$NEWLINE
 More details can be found in  workflow \"$GITHUB_WORKFLOW\" at https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+  # Add label denoting inability to automatically rebase
+  "${LABEL_ON_FAILURE}" && /ghcli/bin/gh pr edit $1 --add-label "$FAILED_LABEL"
 }
 
 for PR_NUMBER in $PR_NUMBERS
@@ -20,6 +28,9 @@ do
   then
     REASON=$( echo "$OUTPUT" | tail -n "${LOG_LINES}" )
     rebase_failure "$PR_NUMBER" "$REASON"
+  else
+    # On success, remove label that indicates past failure
+    /ghcli/bin/gh pr edit $PR_NUMBER --remove-label "$FAILED_LABEL"
   fi
 
   # Remove fork remote for subsequent rebases


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2041**

### Brief description. What is this change?

This change allows the action to apply the `unable-auto-rebase` label on failure to rebase. This label simultaneously signals that humans need to manually rebase the given PR and prevents further rebase comments from spamming the PR.

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

This action will add the necessary label to the repo if it is not already there

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->
